### PR TITLE
Fix documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Assuming you are running Fedora.
     git clone git@github.com:torvalds/linux.git
     git clone git@github.com:razaaliraza/ukl.git
     git clone git@github.com:razaaliraza/min-initrd.git
+    ln -s ../../../ukl/ukl.h linux/include/linux/
     cd ukl
 ```
 


### PR DESCRIPTION
Just a small fix in the compilation process, as ukl.h cannot be found using
the current documentation.