### PR TITLE
Fixing missing packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Assuming you are running Fedora, you need the following packages. Run the following command to install them.
 ```
-    sudo dnf install qemu supermin git elfutils-devel kernel-devel
+    sudo dnf install qemu supermin git elfutils-devel kernel-devel openssl-devel
     sudo dnf groupinstall "C Development Tools and Libraries"
 ```
 


### PR DESCRIPTION
This patchset updates the README file to include instructions
about missing openssl-devel package.

Issue: https://github.com/razaaliraza/ukl/issues/5